### PR TITLE
Remove break after agency.txt is found in zip file in order to process stops.txt for bounds

### DIFF
--- a/contrib/background_processor.py
+++ b/contrib/background_processor.py
@@ -213,7 +213,6 @@ Please correct the error and re-try this upload.
                 logging.info('reading for %r' % filename)
                 agencydata = zip_data.read(filename)
                 logging.info('%r' % agencydata)
-                break
             if filename == 'stops.txt' or filename.endswith('/stops.txt'):
                 bounds = get_bounds_str(zip_data.read(filename))
         if not agencydata:


### PR DESCRIPTION
Hey Jehiah,

thanks for merging the bounds code into the refactor (and prettifying my code)!
However, I believe you mistakenly left the break inside the loop which will skip the processing of the stops.txt file if it happens to come after agency.txt (not sure about the ordering in zip.namelist()).

Cheers
Stefan
